### PR TITLE
Fix checkboxes in Firefox and IE/Edge

### DIFF
--- a/index.css
+++ b/index.css
@@ -112,28 +112,32 @@ body {
 	border-top: 1px solid #e6e6e6;
 }
 
-label[for='toggle-all'] {
-	display: none;
-}
-
 .toggle-all {
-	position: absolute;
-	top: -55px;
-	left: -12px;
-	width: 60px;
-	height: 34px;
 	text-align: center;
 	border: none; /* Mobile Safari */
+	opacity: 0;
+	position: absolute;
 }
 
-.toggle-all:before {
+.toggle-all + label {
+	width: 60px;
+	height: 34px;
+	font-size: 0;
+	position: absolute;
+	top: -52px;
+	left: -13px;
+	-webkit-transform: rotate(90deg);
+	transform: rotate(90deg);
+}
+
+.toggle-all + label:before {
 	content: '❯';
 	font-size: 22px;
 	color: #e6e6e6;
 	padding: 10px 27px 10px 27px;
 }
 
-.toggle-all:checked:before {
+.toggle-all:checked + label:before {
 	color: #737373;
 }
 
@@ -183,18 +187,27 @@ label[for='toggle-all'] {
 	appearance: none;
 }
 
-.todo-list li .toggle:after {
-	content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="none" stroke="#ededed" stroke-width="3"/></svg>');
+.todo-list li .toggle {
+	opacity: 0;
 }
 
-.todo-list li .toggle:checked:after {
-	content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="none" stroke="#bddad5" stroke-width="3"/><path fill="#5dc2af" d="M72 25L42 71 27 56l-4 4 20 20 34-52z"/></svg>');
+.todo-list li .toggle + label {
+	/*firefox only requires # to be escaped - https://bugzilla.mozilla.org/show_bug.cgi?id=922433*/
+	/* IE and Edge required _everything_ to be escaped to render, so we do that instead of just the # - https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7157459/ */
+	background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23ededed%22%20stroke-width%3D%223%22/%3E%3C/svg%3E');
+	background-repeat: no-repeat;
+	background-position: center left;
+}
+
+.todo-list li .toggle:checked + label {
+	/*firefox only requires # to be escaped - https://bugzilla.mozilla.org/show_bug.cgi?id=922433*/
+	/* IE and Edge required _everything_ to be escaped to render, so we do that instead of just the # - https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7157459/ */
+	background-image: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2240%22%20height%3D%2240%22%20viewBox%3D%22-10%20-18%20100%20135%22%3E%3Ccircle%20cx%3D%2250%22%20cy%3D%2250%22%20r%3D%2250%22%20fill%3D%22none%22%20stroke%3D%22%23bddad5%22%20stroke-width%3D%223%22/%3E%3Cpath%20fill%3D%22%235dc2af%22%20d%3D%22M72%2025L42%2071%2027%2056l-4%204%2020%2020%2034-52z%22/%3E%3C/svg%3E');
 }
 
 .todo-list li label {
 	word-break: break-all;
-	padding: 15px 60px 15px 15px;
-	margin-left: 45px;
+	padding: 15px 15px 15px 60px;
 	display: block;
 	line-height: 1.2;
 	transition: color 0.4s;
@@ -349,13 +362,6 @@ html .clear-completed:active {
 
 	.todo-list li .toggle {
 		height: 40px;
-	}
-
-	.toggle-all {
-		-webkit-transform: rotate(90deg);
-		transform: rotate(90deg);
-		-webkit-appearance: none;
-		appearance: none;
 	}
 }
 


### PR DESCRIPTION
firefox doesn't allow for the input elements style to be completely overwritten
like it has been in chrome. So instead I am hiding the checkbox via opacity and
loading the checkbox as the background of the label. This has the nice side
effect of fixing an issue with Edge and svg backgrounds on input elements.
Finally, firefox is choking on `#` in svg data uris. escaping the url fixes
that.

closes tastejs/todomvc#1408

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tastejs/todomvc-app-css/8)

<!-- Reviewable:end -->
