### PR TITLE
Remove duplicate position:relative for .clear-completed

### DIFF
--- a/index.css
+++ b/index.css
@@ -316,7 +316,6 @@ html .clear-completed:active {
 	line-height: 20px;
 	text-decoration: none;
 	cursor: pointer;
-	position: relative;
 }
 
 .clear-completed:hover {


### PR DESCRIPTION
```css
position:relative
```
is declared twice.