### PR TITLE
Prefer css content codes over character

### DIFF
--- a/index.css
+++ b/index.css
@@ -129,7 +129,7 @@ label[for='toggle-all'] {
 }
 
 .toggle-all:before {
-	content: '❯';
+	content: '\276F';
 	font-size: 22px;
 	color: #e6e6e6;
 	padding: 10px 27px 10px 27px;
@@ -228,7 +228,7 @@ label[for='toggle-all'] {
 }
 
 .todo-list li .destroy:after {
-	content: '×';
+	content: '\00d7';
 }
 
 .todo-list li:hover .destroy {


### PR DESCRIPTION
I found that these special characters were replaces with `â¯` when importing using browserify. 
Changing these to the content codes should prevent any issues.