### PR TITLE
Fix the padding values in the edit mode input.

### DIFF
--- a/index.css
+++ b/index.css
@@ -163,7 +163,7 @@ label[for='toggle-all'] {
 .todo-list li.editing .edit {
 	display: block;
 	width: 506px;
-	padding: 13px 17px 12px 17px;
+	padding: 12px 16px;
 	margin: 0 0 0 43px;
 }
 


### PR DESCRIPTION
The previous values caused layout thrashing when transitioning between edit and label mode.