### PR TITLE
Fix toggle-all input not being checked

### DIFF
--- a/index.css
+++ b/index.css
@@ -388,5 +388,4 @@ html .clear-completed:active {
 .toggle-all:focus + label {
 	box-shadow: 0 0 2px 2px #CF7D7D;
 	outline: 0;
-	z-index: 3;
 }


### PR DESCRIPTION
Fix #37 .

When the new-todo input is selected, its z-index is greater than toggle-all input, resulting in the toggle-all input can't be checked.

So I removed changing the z-Index property when an element is selected. 